### PR TITLE
Add function to fill an histogram passed to the function

### DIFF
--- a/TDataFrame.hpp
+++ b/TDataFrame.hpp
@@ -184,15 +184,20 @@ class TTmpDataFrame {
    }
 
    template<class T>
+   void fillhist(std::string branch, TH1& histogram) {
+       TTreeReaderValue<T> v(t, branch.c_str());
+       while(t.Next())
+          if(apply_filters())
+             histogram.Fill(*v);
+   }
+
+
+   template<class T>
    TH1F fillhist(std::string branch, unsigned nbins = 100,
                  std::string name_suffix = "") {
       // histogram with automatic binning
       TH1F h(("h_" + branch).c_str(), branch.c_str(), nbins, 0., 0.);
-      TTreeReaderValue<T> v(t, branch.c_str());
-      while(t.Next())
-         if(apply_filters())
-            h.Fill(*v);
-
+      fillhist<T>(branch, h);
       return h;
    }
 

--- a/tdf001_introduction.C
+++ b/tdf001_introduction.C
@@ -86,7 +86,11 @@ int tdf001_introduction() {
    // The `fillhist` action allows to fill an histogram. It returns a TH1F filled 
    // with values of the branch that passed the filters.
    auto hist = d.filter(cutb1, {"b1"}).fillhist<double>("b1");
-   std::cout << "\nfilled h " << hist.GetEntries() << " times" << std::endl;
+   std::cout << "\nfilled h " << hist.GetEntries() << " times, mean: " << hist.GetMean() << std::endl;
+
+   TH1D hist2("hist2", "hist2", 200, 0, 20);
+   d.filter(cutb1, {"b1"}).fillhist<double>("b1", hist2);
+   std::cout << "\nfilled h2 " << hist2.GetEntries() << " times, mean: " << hist2.GetMean() << std::endl;
 
    // ### `foreach` action
    // The most generic action of all: an operation is applied to all entries. 


### PR DESCRIPTION
This is a small variation of the fillhist method. As in the updated example you can now also do:

    TH1D hist2("hist2", "hist2", 200, 0, 20);
    d.filter(cutb1, {"b1"}).fillhist<double>("b1", hist2);
