### PR TITLE
Add TDataFrameProxy and allow to re-attach actions to saved proxies after running

### DIFF
--- a/TDataFrame.hxx
+++ b/TDataFrame.hxx
@@ -338,6 +338,16 @@ enum class EActionType : short {
    kMean
 };
 
+template<typename Derived> class TDataFrameInterface;
+
+// A proxy for TDataFrame{Filter,Branch}. De facto it is a workaround for a smart reference.
+template<typename Derived>
+class TDataFrameProxy : public TDataFrameInterface<Derived> {
+   Derived *fDerivedPtr;
+public:
+   TDataFrameProxy(TDataFrameInterface<Derived> *iface) : TDataFrameInterface<Derived>(iface), fDerivedPtr(static_cast<Derived*>(iface)) { }
+   TDataFrame& GetDataFrame() const {return fDerivedPtr->GetDataFrame();}
+};
 
 // this class provides a common public interface to TDataFrame and TDataFrameFilter
 // it contains the Filter call and all action calls
@@ -345,30 +355,31 @@ template<typename Derived>
 class TDataFrameInterface {
 public:
    TDataFrameInterface() : fDerivedPtr(static_cast<Derived*>(this)) { }
+   TDataFrameInterface(TDataFrameInterface<Derived>* derived) : fDerivedPtr(static_cast<Derived*>(derived)) { }
    virtual ~TDataFrameInterface() { }
 
    template<typename F>
-   auto Filter(F f, const BranchList& bl = {}) -> TDataFrameFilter<F, Derived>& {
+   auto Filter(F f, const BranchList& bl = {}) -> TDataFrameProxy<TDataFrameFilter<F, Derived>> {
       ::CheckFilter(f);
       const BranchList& defBl = fDerivedPtr->GetDataFrame().GetDefaultBranches();
       const BranchList& actualBl = ::PickBranchList(f, bl, defBl);
       using DFF = TDataFrameFilter<F, Derived>;
       auto FilterPtr = std::unique_ptr<DFF>(new DFF(f, actualBl, *fDerivedPtr));
-      auto& FilterRef = *FilterPtr;
+      TDataFrameProxy<DFF> dffProxy(FilterPtr.get());
       Book(std::move(FilterPtr));
-      return FilterRef;
+      return dffProxy;
    }
 
    template<typename F>
    auto AddBranch(const std::string& name, F expression, const BranchList& bl = {})
-   -> TDataFrameBranch<F, Derived>& {
+   -> TDataFrameProxy<TDataFrameBranch<F, Derived>> {
       const BranchList& defBl = fDerivedPtr->GetDataFrame().GetDefaultBranches();
       const BranchList& actualBl = ::PickBranchList(expression, bl, defBl);
       using DFB = TDataFrameBranch<F, Derived>;
       auto BranchPtr = std::unique_ptr<DFB>(new DFB(name, expression, actualBl, *fDerivedPtr));
-      auto& BranchRef = *BranchPtr;
+      TDataFrameProxy<DFB> dfbProxy(BranchPtr.get());
       Book(std::move(BranchPtr));
-      return BranchRef;
+      return dfbProxy;
    }
 
    template<typename F>

--- a/TDataFrame.hxx
+++ b/TDataFrame.hxx
@@ -764,10 +764,8 @@ public:
          for(auto& actionPtr : fBookedActions)
             actionPtr->Run(r.GetCurrentEntry());
 
-      // forget everything
+      // forget actions and "detach" the action result pointers marking them ready and forget them too
       fBookedActions.clear();
-      fBookedFilters.clear();
-      fBookedBranches.clear();
       for (auto aptr : fActionResultsPtrs) {
          aptr->SetReady();
       }

--- a/test_checker/test2.out
+++ b/test_checker/test2.out
@@ -80,3 +80,6 @@ Mean dv: 5.13793
 115.616
 50.1965
 50.6713
+Count for the first run is 18
+Count for the second run after adding a filter is 8
+Count for the first run was 18

--- a/tests/tdf001_introduction.cxx
+++ b/tests/tdf001_introduction.cxx
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_tdataframe
 /// \notebook -nodraw
-/// This tutorial illustrates the basic features of the TDataFrame class, 
+/// This tutorial illustrates the basic features of the TDataFrame class,
 /// a utility which allows to interact with data stored in TTrees following
 /// a functional-chain like approach.
 ///
@@ -21,7 +21,7 @@
 
 #include "TDataFrame.hxx"
 
-// A simple helper function to fill a test tree: this makes the example 
+// A simple helper function to fill a test tree: this makes the example
 // stand-alone.
 void fill_tree(const char* filename, const char* treeName) {
    TFile f(filename,"RECREATE");
@@ -47,7 +47,7 @@ int tdf001_introduction() {
    auto treeName = "myTree";
    fill_tree(fileName,treeName);
 
-   // We read the tree from the file and create a TDataFrame, a class that 
+   // We read the tree from the file and create a TDataFrame, a class that
    // allows us to interact with the data contained in the tree.
    // We select a default column, a *branch* to adopt ROOT jargon, which will
    // be looked at if none is specified by the user when dealing with filters
@@ -55,7 +55,7 @@ int tdf001_introduction() {
    TFile f(fileName);
    TDataFrame d(treeName, &f, {"b1"});
 
-   // ## Operations on the dataframe 
+   // ## Operations on the dataframe
    // We now review some *actions* which can be performed on the data frame.
    // All actions but ForEach return a TActionResultPtr<T>. The series of
    // operations on the data frame is not executed until one of those pointers
@@ -78,18 +78,18 @@ int tdf001_introduction() {
    // ### `Min`, `Max` and `Mean` actions
    // These actions allow to retrieve statistical information about the entries
    // passing the cuts, if any.
-   auto& b1b2_cut = d.Filter(cutb1b2, {"b2","b1"});
+   auto b1b2_cut = d.Filter(cutb1b2, {"b2","b1"});
    auto minVal = b1b2_cut.Min();
    auto maxVal = b1b2_cut.Max();
    auto meanVal = b1b2_cut.Mean("b2"); // <- Here the column is not the default one.
-   std::cout << "The mean is always included between the min and the max: " 
+   std::cout << "The mean is always included between the min and the max: "
              << *minVal << " <= " << *meanVal << " <= " << *maxVal << std::endl;
 
    // ### `Get` action
-   // The `Get` action allows to retrieve all values of the variable stored in a 
+   // The `Get` action allows to retrieve all values of the variable stored in a
    // particular column that passed filters we specified. The values are stored
    // in a list by default, but other collections can be chosen.
-   auto& b1_cut = d.Filter(cutb1);
+   auto b1_cut = d.Filter(cutb1);
    auto b1List = b1_cut.Get<double>();
    auto b1Vec = b1_cut.Get<double, std::vector<double>>();
 
@@ -101,7 +101,7 @@ int tdf001_introduction() {
    std::cout << "The type of b1Vec is" << b1VecCl->GetName() << std::endl;
 
    // ### `Histo` action
-   // The `Histo` action allows to fill an histogram. It returns a TH1F filled 
+   // The `Histo` action allows to fill an histogram. It returns a TH1F filled
    // with values of the column that passed the filters. For the most common
    // types, the type of the values stored in the column is automatically
    // guessed.
@@ -109,8 +109,8 @@ int tdf001_introduction() {
    std::cout << "Filled h " << hist->GetEntries() << " times, mean: " << hist->GetMean() << std::endl;
 
    // ### `Foreach` action
-   // The most generic action of all: an operation is applied to all entries. 
-   // In this case we fill a histogram. In some sense this is a violation of a 
+   // The most generic action of all: an operation is applied to all entries.
+   // In this case we fill a histogram. In some sense this is a violation of a
    // purely functional paradigm - C++ allows to do that.
    TH1F h("h", "h", 12, -1, 11);
    d.Filter([](int b2) { return b2 % 2 == 0; }, {"b2"})
@@ -126,9 +126,9 @@ int tdf001_introduction() {
    // or again to clearly separate filters and actions without the need of
    // writing the entire pipeline on one line. This can be easily achieved.
    // We'll show this re-working the `Count` example:
-   auto& cutb1_result = d.Filter(cutb1);
-   auto& cutb1b2_result = d.Filter(cutb1b2, {"b2","b1"});
-   auto& cutb1_cutb1b2_result = cutb1_result.Filter(cutb1b2, {"b2","b1"});
+   auto cutb1_result = d.Filter(cutb1);
+   auto cutb1b2_result = d.Filter(cutb1b2, {"b2","b1"});
+   auto cutb1_cutb1b2_result = cutb1_result.Filter(cutb1b2, {"b2","b1"});
    // Now we want to count:
    auto evts_cutb1_result = cutb1_result.Count();
    auto evts_cutb1b2_result = cutb1b2_result.Count();

--- a/tests/tdf002_dataModel.cxx
+++ b/tests/tdf002_dataModel.cxx
@@ -29,7 +29,7 @@ using FourVector = ROOT::Math::XYZTVector;
 using FourVectors = std::vector<FourVector>;
 using CylFourVector = ROOT::Math::RhoEtaPhiVector;
 
-// A simple helper function to fill a test tree: this makes the example 
+// A simple helper function to fill a test tree: this makes the example
 // stand-alone.
 void fill_tree(const char* filename, const char* treeName) {
    TFile f(filename,"RECREATE");
@@ -72,7 +72,7 @@ int tdf002_dataModel() {
    auto treeName = "myTree";
    fill_tree(fileName,treeName);
 
-   // We read the tree from the file and create a TDataFrame, a class that 
+   // We read the tree from the file and create a TDataFrame, a class that
    // allows us to interact with the data contained in the tree.
    TFile f(fileName);
    TDataFrame d(treeName, &f, {"tracks"});
@@ -98,9 +98,9 @@ int tdf002_dataModel() {
       return pts;
       };
 
-   auto& augmented_d = d.AddBranch("tracks_n", [](const FourVectors& tracks){return (int)tracks.size();})
-                        .Filter([](int tracks_n){return tracks_n > 2;}, {"tracks_n"})
-                        .AddBranch("tracks_pts", getPt);
+   auto augmented_d = d.AddBranch("tracks_n", [](const FourVectors& tracks){return (int)tracks.size();})
+                       .Filter([](int tracks_n){return tracks_n > 2;}, {"tracks_n"})
+                       .AddBranch("tracks_pts", getPt);
 
    auto trN = augmented_d.Histo("tracks_n",40,-.5,39.5);
    auto trPts = augmented_d.Histo("tracks_pts");

--- a/tests/test2.cxx
+++ b/tests/test2.cxx
@@ -90,12 +90,13 @@ int main() {
 
    // TEST 2: Forked actions
    // always apply first filter before doing three different actions
-   auto& dd = d.Filter(ok, {});
+   auto fd = d.Filter(ok, {});
+   auto dd = fd.AddBranch("iseven", [](int b2) { return b2 % 2 == 0; }, {"b2"});
    dd.Foreach([](double x) { std::cout << x << " "; }, {"b1"});
    dd.Foreach([](int y) { std::cout << y << std::endl; }, {"b2"});
    auto c = dd.Count();
    // ... and another filter-and-foreach
-   auto& ddd = dd.Filter(ko, {});
+   auto ddd = dd.Filter(ko, {});
    ddd.Foreach([]() { std::cout << "ERROR" << std::endl; }, {});
    d.Run();
    auto cv = *c;
@@ -104,7 +105,7 @@ int main() {
 
    // TEST 3: default branches
    TDataFrame d2(treeName, &f, {"b1"});
-   auto& d2f = d2.Filter([](double b1) { return b1 < 5; }).Filter(ok, {});
+   auto d2f = d2.Filter([](double b1) { return b1 < 5; }).Filter(ok, {});
    auto c2 = d2f.Count();
    d2f.Foreach([](double b1) { std::cout << b1 << std::endl; });
    d2.Run();
@@ -114,7 +115,7 @@ int main() {
 
    // TEST 4: execute Run lazily and implicitly
    TDataFrame d3(treeName, &f, {"b1"});
-   auto& d3f = d3.Filter([](double b1) { return b1 < 4; }).Filter(ok, {});
+   auto d3f = d3.Filter([](double b1) { return b1 < 4; }).Filter(ok, {});
    auto c3 = d3f.Count();
    auto c3v = *c3;
    std::cout << "c3 " << c3v << std::endl;
@@ -122,7 +123,7 @@ int main() {
 
    // TEST 5: non trivial branch
    TDataFrame d4(treeName, &f, {"tracks"});
-   auto& d4f = d4.Filter([](FourVectors const & tracks) { return tracks.size() > 7; });
+   auto d4f = d4.Filter([](FourVectors const & tracks) { return tracks.size() > 7; });
    auto c4 = d4f.Count();
    auto c4v = *c4;
    std::cout << "c4 " << c4v << std::endl;
@@ -151,12 +152,12 @@ int main() {
 
    // TEST 8: AddBranch with default branches, filters, non-trivial types
    TDataFrame d7(treeName, &f, {"tracks"});
-   auto& dd7 = d7.Filter([](int b2) { return b2 % 2 == 0; }, {"b2"})
-                 .AddBranch("ptsum", [](FourVectors const & tracks) {
-                    double sum = 0;
-                    for(auto& track: tracks)
-                       sum += track.Pt();
-                    return sum; });
+   auto dd7 = d7.Filter([](int b2) { return b2 % 2 == 0; }, {"b2"})
+                .AddBranch("ptsum", [](FourVectors const & tracks) {
+                   double sum = 0;
+                   for(auto& track: tracks)
+                      sum += track.Pt();
+                   return sum; });
    auto c7 = dd7.Count();
    auto h7 = dd7.Histo("ptsum");
    auto c7v = *c7.get();
@@ -196,12 +197,12 @@ int main() {
 
    // TEST 10: Get a full column
    TDataFrame d9(treeName, &f, {"tracks"});
-   auto& dd9 = d9.Filter([](int b2) { return b2 % 2 == 0; }, {"b2"})
-                 .AddBranch("ptsum", [](FourVectors const & tracks) {
-                    double sum = 0;
-                    for(auto& track: tracks)
-                       sum += track.Pt();
-                    return sum; });
+   auto dd9 = d9.Filter([](int b2) { return b2 % 2 == 0; }, {"b2"})
+                .AddBranch("ptsum", [](FourVectors const & tracks) {
+                   double sum = 0;
+                   for(auto& track: tracks)
+                      sum += track.Pt();
+                   return sum; });
    auto b2List = dd9.Get<int>("b2");
    auto ptsumVec = dd9.Get<double, std::vector<double>>("ptsum");
 

--- a/tests/test2.cxx
+++ b/tests/test2.cxx
@@ -214,6 +214,15 @@ int main() {
       std::cout << v << std::endl;
    }
 
+   // TEST 11: Re-hang action to TDataFrameProxy after running
+   TDataFrame d10(treeName, &f, {"tracks"});
+   auto d10f = d10.Filter([](FourVectors const & tracks) { return tracks.size() > 2; });
+   auto c10 = d10f.Count();
+   std::cout << "Count for the first run is " << *c10 << std::endl;
+   auto d10f_2 = d10f.Filter([](FourVectors const & tracks) { return tracks.size() < 5; });
+   auto c10_2 = d10f_2.Count();
+   std::cout << "Count for the second run after adding a filter is " << *c10_2 << std::endl;
+   std::cout << "Count for the first run was " << *c10 << std::endl;
 
    return 0;
 }

--- a/tests/test_ctors.cxx
+++ b/tests/test_ctors.cxx
@@ -30,8 +30,8 @@ void test_ctors() {
    std::cout << "building dataframe...\n";
    TDataFrame d(treeName, &f, {"obj"});
    std::cout << "done\nbuilding chain...\n";
-   auto& dd = d.Filter([](const Sentinel& o) { std::cout << "filter\n"; return o.get() > 0; })
-               .AddBranch("x", [](const Sentinel& o) { std::cout << "addbranch\n"; return o.get(); });
+   auto dd = d.Filter([](const Sentinel& o) { std::cout << "filter\n"; return o.get() > 0; })
+              .AddBranch("x", [](const Sentinel& o) { std::cout << "addbranch\n"; return o.get(); });
    auto r = dd.Count();
    dd.Foreach([](const Sentinel& o) { std::cout << "foreach: " << o.get() << std::endl; });
    std::cout << "done\n";


### PR DESCRIPTION
The TDataFrameProxy class has been added. Now forking the cutflow is even easier (no auto& needed):
`auto myFilteredDF = myDF.Filter(myFilter);`
In addition this paves the way of reference counting the filters to optimise results caching (it is actually one template specialisation away)

In addition the cleanup after running is less radical. Action results are set ready to be used and actions forgotten but filters and branches are kept: several runs can be performed with different sets of actions w/o re-creating the frame or leaving around dangling references (#42)