### PR TITLE
Fix dangling references (issue #64)

### DIFF
--- a/test_checker/check.sh
+++ b/test_checker/check.sh
@@ -12,7 +12,8 @@ popd > /dev/null
 
 echo "checking executables..."
 FILES=(test_misc testIMT tdf001_introduction tdf002_dataModel regression_multipletriggerrun \
-       test_functiontraits regression_zeroentries test_branchoverwrite test_foreach)
+       test_functiontraits regression_zeroentries test_branchoverwrite test_foreach \
+       regression_invalidref)
 RETCODE=0
 for F in ${FILES[@]}; do
    ../tests/$F | diff $F.out -

--- a/test_checker/regression_invalidref.out
+++ b/test_checker/regression_invalidref.out
@@ -1,0 +1,1 @@
+Exception catched: the dataframe went out of scope when booking a filter

--- a/tests/makefile
+++ b/tests/makefile
@@ -1,6 +1,6 @@
 TESTS:=tdf001_introduction tdf002_dataModel test_misc regression_multipletriggerrun \
 test_par testIMT test_functiontraits regression_zeroentries test_branchoverwrite \
-test_foreach
+test_foreach regression_invalidref
 
 all: $(TESTS)
 

--- a/tests/regression_invalidref.cxx
+++ b/tests/regression_invalidref.cxx
@@ -1,0 +1,19 @@
+#include "TDataFrame.hxx"
+#include <exception>
+
+auto FilteredDFFactory = []() {
+   ROOT::TDataFrame d("", nullptr);
+   auto f = d.Filter([]() { return true; });
+   return f;
+};
+
+int main() {
+   auto f = FilteredDFFactory();
+   try {
+      f.Filter([]() { return true; });
+   } catch (const std::runtime_error& e) {
+      std::cout << "Exception catched: the dataframe went out of scope when booking a filter" << std::endl;
+   }
+
+   return 0;
+}


### PR DESCRIPTION
This is a fairly fat commit because I had to change several things that were all entangled with each other:

- `GetDataFrameChecked` now returns a `shared_ptr` to `TDataFrameImpl` or throws if the data-frame was deleted
- `Filter`, `AddBranch` and all actions now call `GetDataFrameChecked` before anything else, then always use the `shared_ptr<TDataFrameImpl>` obtained this way for their operations
- ctors of `TActionResultPtr{,Base}`, `TDataFrame{Filter,Branch}` now take `shared_ptr`s instead of `weak_ptr`s: validity must be checked before passing these pointer to the ctors
- `Book` methods have been removed from `TDataFrame{Interface,Filter,Branch}`: they can call
  `TDataFrameImpl::Book` directly